### PR TITLE
Build information wiki migration

### DIFF
--- a/HEX_IMPLEMENTATION_SUMMARY.md
+++ b/HEX_IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,9 @@
 # HEX Compilation Implementation Summary
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Teensy-HEX](wiki/Build-Teensy-HEX.md) and
+> [Build-Teensy-CLI](wiki/Build-Teensy-CLI.md).
+
 This document summarizes the implementation for compiling Teensy 4.1 firmware to HEX format.
 
 ## What Was Implemented

--- a/POVPoiApp/README.md
+++ b/POVPoiApp/README.md
@@ -1,5 +1,8 @@
 # Nebula Poi Controller - Android App
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Android-App](../wiki/Build-Android-App.md).
+
 A complete Android application for controlling the Nebula Poi with advanced image conversion capabilities.
 
 ## Features

--- a/QUICK_HEX_GUIDE.md
+++ b/QUICK_HEX_GUIDE.md
@@ -1,5 +1,9 @@
 # Quick Guide: Compiling to HEX Format
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Teensy-HEX](wiki/Build-Teensy-HEX.md) and
+> [Build-Teensy-CLI](wiki/Build-Teensy-CLI.md).
+
 Need to compile the Teensy firmware to HEX format for the Teensy Loader? Here's the fastest way:
 
 ## 🎯 The Big Picture

--- a/README.md
+++ b/README.md
@@ -93,9 +93,10 @@ See [docs/WIRING.md](docs/WIRING.md) for detailed wiring instructions.
 **Alternative: Build HEX file for Teensy Loader**
 - Use Sketch > Export Compiled Binary in Arduino IDE
 - Or use CLI build scripts: `./scripts/build_arduino_cli.sh` or `./scripts/build_teensy_hex.sh` (Linux/Mac)
+- **Build Wiki**: See [Build Overview](wiki/Build-Overview.md),
+  [Teensy HEX](wiki/Build-Teensy-HEX.md), and
+  [Teensy CLI](wiki/Build-Teensy-CLI.md)
 - **Quick Guide**: See [QUICK_HEX_GUIDE.md](QUICK_HEX_GUIDE.md) for fast start
-- **CLI Guide**: See [CLI Compilation](docs/CLI_COMPILATION.md) for command-line builds
-- **Detailed Guide**: See [Building HEX Files](docs/BUILDING_HEX.md) for complete instructions
 
 **Program the ESP32 or ESP32-S3:**
 

--- a/docs/BUILDING_HEX.md
+++ b/docs/BUILDING_HEX.md
@@ -1,5 +1,9 @@
 # Building HEX Files for Teensy Loader
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Teensy-HEX](../wiki/Build-Teensy-HEX.md) and
+> [Build-Teensy-CLI](../wiki/Build-Teensy-CLI.md).
+
 This guide explains how to compile the Teensy 4.1 firmware into a HEX file format that can be loaded using the Teensy Loader application.
 
 ## Prerequisites

--- a/docs/CLI_COMPILATION.md
+++ b/docs/CLI_COMPILATION.md
@@ -1,5 +1,8 @@
 # CLI Compilation Guide for Teensy 4.1 Firmware
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Teensy-CLI](../wiki/Build-Teensy-CLI.md).
+
 Complete guide for compiling Teensy firmware from the command line.
 
 ## Overview

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,7 +125,9 @@ If you prefer to use the Teensy Loader application:
 4. Open Teensy Loader and load the generated `.hex` file
 5. Press the button on your Teensy to program it
 
-See [BUILDING_HEX.md](BUILDING_HEX.md) for detailed instructions on building and loading HEX files.
+See the build wiki for HEX and CLI instructions:
+[Build-Teensy-HEX](../wiki/Build-Teensy-HEX.md) and
+[Build-Teensy-CLI](../wiki/Build-Teensy-CLI.md).
 
 ### Programming the ESP32 or ESP32-S3
 

--- a/esp32_firmware/README_COMPILE.md
+++ b/esp32_firmware/README_COMPILE.md
@@ -1,5 +1,8 @@
 # Compiling and Uploading ESP32 Firmware
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-ESP32-Firmware](../wiki/Build-ESP32-Firmware.md).
+
 ## Quick Start
 
 ### Option 1: Using the Batch Script (Easiest)

--- a/examples/BUILD_INSTALLER.md
+++ b/examples/BUILD_INSTALLER.md
@@ -1,5 +1,8 @@
 # Building Windows Executable for Nebula Poi Image Converter
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Image-Converter](../wiki/Build-Image-Converter.md).
+
 This guide explains how to create a standalone Windows executable (.exe) for the Nebula Poi Image Converter GUI, allowing Windows users to run the application without installing Python.
 
 ## Table of Contents

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,8 @@
 # POV Image Converter Tools
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Image-Converter](../wiki/Build-Image-Converter.md).
+
 ## GUI Image Converter (Recommended for Desktop)
 
 ### Installation

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,9 @@
 # Build Scripts
 
+> Note: Build documentation has moved to the wiki.
+> See [Build-Teensy-CLI](../wiki/Build-Teensy-CLI.md) and
+> [Build-Teensy-HEX](../wiki/Build-Teensy-HEX.md).
+
 This directory contains scripts for building the Teensy 4.1 firmware into HEX format for use with the Teensy Loader application.
 
 ## Available Scripts

--- a/wiki/Build-Android-App.md
+++ b/wiki/Build-Android-App.md
@@ -1,0 +1,41 @@
+# Android App Build
+
+The Android app lives in `POVPoiApp/`.
+
+## Requirements
+
+- Android Studio Electric Eel (2022.1.1) or later
+- Android SDK API 21+
+- JDK 8 or later
+
+## Android Studio
+
+1. Open Android Studio.
+2. **File > Open** and select the `POVPoiApp/` directory.
+3. Wait for Gradle sync to finish.
+
+Build:
+- **Build > Make Project** (Ctrl+F9 / Cmd+F9)
+
+Run:
+- Select a device or emulator and click **Run**.
+
+## Gradle CLI
+
+```bash
+cd POVPoiApp
+./gradlew build
+./gradlew assembleDebug
+```
+
+## Release APK
+
+1. **Build > Generate Signed Bundle / APK**.
+2. Choose **APK** and create or select a keystore.
+3. Select build variant **release**.
+4. APK output: `POVPoiApp/app/release/app-release.apk`
+
+## Common issues
+
+- Missing SDK components: open **SDK Manager** and install required items.
+- Gradle sync failures: **File > Invalidate Caches / Restart**.

--- a/wiki/Build-ESP32-Firmware.md
+++ b/wiki/Build-ESP32-Firmware.md
@@ -1,0 +1,64 @@
+# ESP32 Firmware Build
+
+The ESP32 firmware is located at `esp32_firmware/esp32_firmware.ino`.
+
+## Arduino IDE
+
+### ESP32 (WROOM-32 and similar)
+
+1. Open `esp32_firmware/esp32_firmware.ino`.
+2. Select **Tools > Board > ESP32 Dev Module**.
+3. Select the correct serial port.
+4. Set **Partition Scheme > Default** (or "Minimal SPIFFS" for 4MB flash).
+5. Set **Flash Size > 4MB (32Mb)**.
+6. Click **Upload**.
+
+### ESP32-S3
+
+1. Open `esp32_firmware/esp32_firmware.ino`.
+2. Select **Tools > Board > ESP32S3 Dev Module**.
+3. Select the correct serial port.
+4. Set **USB CDC On Boot > Enabled**.
+5. Set **Partition Scheme > 16MB Flash (3MB APP/9.9MB FATFS)**.
+6. Click **Upload**.
+
+## PlatformIO
+
+### Root `platformio.ini`
+
+```bash
+# From repo root
+pio run -e esp32
+pio run -e esp32s3
+
+# Upload
+pio run -e esp32 -t upload
+pio run -e esp32s3 -t upload
+```
+
+### Local `esp32_firmware/platformio.ini`
+
+```bash
+cd esp32_firmware
+pio run -e esp32
+pio run -e esp32 -t upload
+```
+
+## Windows batch script
+
+For ESP32 (Windows only), you can use:
+
+```cmd
+esp32_firmware\build_and_upload.bat
+```
+
+## Serial monitor
+
+```bash
+pio device monitor --port /dev/ttyUSB0 --baud 115200
+```
+
+## Troubleshooting
+
+- If upload fails, hold the BOOT button during upload.
+- If you see SPIFFS mount errors, try a different partition scheme.

--- a/wiki/Build-Image-Converter.md
+++ b/wiki/Build-Image-Converter.md
@@ -1,0 +1,50 @@
+# Image Converter Builds
+
+The image converter tools live in `examples/`.
+
+## Python GUI (cross-platform)
+
+Install dependencies:
+
+```bash
+cd examples
+pip install -r requirements.txt
+```
+
+Run the GUI:
+
+```bash
+python image_converter_gui.py
+```
+
+## Windows executable (no Python required)
+
+Prerequisites:
+- Windows 7 or later
+- Python 3.7+
+
+Build steps:
+
+```bash
+cd examples
+pip install -r installer_requirements.txt
+python build_windows_installer.py
+```
+
+Output:
+`examples/dist/POV_POI_Image_Converter.exe`
+
+## Manual PyInstaller build (optional)
+
+```bash
+pyinstaller --onefile --windowed --name=POV_POI_Image_Converter ^
+  --add-data="image_converter.py;." ^
+  --hidden-import=PIL --hidden-import=PIL.Image ^
+  --hidden-import=PIL.ImageTk --hidden-import=PIL.ImageEnhance ^
+  image_converter_gui.py
+```
+
+## Troubleshooting
+
+- Missing Pillow: `pip install Pillow`
+- GUI not opening on Linux: `sudo apt-get install python3-tk`

--- a/wiki/Build-Overview.md
+++ b/wiki/Build-Overview.md
@@ -1,0 +1,56 @@
+# Build Overview
+
+This page summarizes the build targets in the Nebula Poi repository and
+points to detailed wiki pages for each target.
+
+## Build targets
+
+- Teensy 4.1 firmware (Arduino IDE or PlatformIO)
+- ESP32 firmware (Arduino IDE or PlatformIO)
+- ESP32-S3 firmware (Arduino IDE or PlatformIO)
+- Android app (Android Studio or Gradle CLI)
+- Image converter tools (Python GUI and Windows executable)
+
+## Quick links
+
+- [Teensy firmware build](Build-Teensy-Firmware.md)
+- [Teensy HEX files](Build-Teensy-HEX.md)
+- [Teensy CLI compilation](Build-Teensy-CLI.md)
+- [ESP32 firmware build](Build-ESP32-Firmware.md)
+- [Android app build](Build-Android-App.md)
+- [Image converter builds](Build-Image-Converter.md)
+
+## PlatformIO quick commands
+
+Use the root `platformio.ini` for unified builds:
+
+```bash
+# Build
+pio run -e teensy41
+pio run -e esp32
+pio run -e esp32s3
+
+# Upload
+pio run -e teensy41 -t upload
+pio run -e esp32 -t upload
+pio run -e esp32s3 -t upload
+```
+
+## Common output locations
+
+- Teensy HEX (Arduino IDE export):
+  `teensy_firmware/teensy_firmware.ino.teensy41.hex`
+- Teensy HEX (PlatformIO):
+  `.pio/build/teensy41/firmware.hex` and `build_output/teensy41_firmware.hex`
+- ESP32 build output (PlatformIO): `.pio/build/esp32/`
+- ESP32-S3 build output (PlatformIO): `.pio/build/esp32s3/`
+- Android APK (release): `POVPoiApp/app/release/app-release.apk`
+- Windows image converter EXE: `examples/dist/POV_POI_Image_Converter.exe`
+
+## Tooling prerequisites
+
+- Arduino IDE 1.8.x or 2.x and Teensyduino
+- PlatformIO (via `pip install platformio`)
+- Arduino CLI (optional, for CLI builds)
+- Android Studio and the Android SDK
+- Python 3.7+ for image converter tools

--- a/wiki/Build-Teensy-CLI.md
+++ b/wiki/Build-Teensy-CLI.md
@@ -1,0 +1,86 @@
+# Teensy CLI Compilation
+
+This page covers CLI workflows for the Teensy 4.1 firmware.
+
+## Arduino CLI
+
+Install:
+
+- Linux:
+  `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh`
+- macOS: `brew install arduino-cli`
+- Windows: `winget install ArduinoSA.CLI`
+
+Setup:
+
+```bash
+arduino-cli config init
+arduino-cli config add board_manager.additional_urls https://www.pjrc.com/teensy/package_teensy_index.json
+arduino-cli core update-index
+arduino-cli core install teensy:avr
+arduino-cli lib install FastLED
+```
+
+Compile:
+
+```bash
+arduino-cli compile \
+  --fqbn teensy:avr:teensy41:usb=serial,speed=600,opt=o2std \
+  teensy_firmware/teensy_firmware.ino \
+  --output-dir teensy_firmware/build
+```
+
+Output:
+`teensy_firmware/build/teensy_firmware.ino.hex`
+
+Upload:
+
+```bash
+arduino-cli upload \
+  --fqbn teensy:avr:teensy41 \
+  --port /dev/ttyACM0 \
+  teensy_firmware/teensy_firmware.ino
+```
+
+## PlatformIO CLI
+
+Install:
+
+```bash
+pip install platformio
+```
+
+Build:
+
+```bash
+pio run -e teensy41
+```
+
+Upload:
+
+```bash
+pio run -e teensy41 -t upload
+```
+
+Build scripts:
+
+```bash
+./scripts/build_arduino_cli.sh
+./scripts/build_teensy_hex.sh
+```
+
+Windows scripts:
+
+```cmd
+scripts\build_arduino_cli.bat
+scripts\build_teensy_hex.bat
+```
+
+## CI quick hint
+
+The PlatformIO build can run headless in CI:
+
+```bash
+pip install platformio
+pio run -e teensy41
+```

--- a/wiki/Build-Teensy-Firmware.md
+++ b/wiki/Build-Teensy-Firmware.md
@@ -1,0 +1,49 @@
+# Teensy 4.1 Firmware Build
+
+The recommended Teensy firmware lives at
+`teensy_firmware/teensy_firmware.ino`.
+
+## Arduino IDE (recommended)
+
+Prerequisites:
+- Arduino IDE 1.8.x or 2.x
+- Teensyduino: https://www.pjrc.com/teensy/td_download.html
+- FastLED library (install via Library Manager)
+
+Steps:
+1. Open `teensy_firmware/teensy_firmware.ino`.
+2. Select **Tools > Board > Teensy 4.1**.
+3. Select **Tools > USB Type > Serial**.
+4. Select **Tools > CPU Speed > 600 MHz**.
+5. Click **Upload**.
+
+## PlatformIO
+
+The root `platformio.ini` includes a `teensy41` environment:
+
+```bash
+# From repo root
+pio run -e teensy41
+pio run -e teensy41 -t upload
+```
+
+Serial monitor:
+
+```bash
+pio device monitor --port /dev/ttyACM0 --baud 115200
+```
+
+## HEX file output
+
+If you prefer using Teensy Loader, build a HEX file:
+
+- Arduino IDE: **Sketch > Export Compiled Binary**
+- PlatformIO scripts: `./scripts/build_teensy_hex.sh` or
+  `scripts\build_teensy_hex.bat`
+
+See [Build-Teensy-HEX](Build-Teensy-HEX.md) for full details.
+
+## Notes
+
+- The Teensy serial baud rate is 115200.
+- PlatformIO copies HEX output to `build_output/teensy41_firmware.hex`.

--- a/wiki/Build-Teensy-HEX.md
+++ b/wiki/Build-Teensy-HEX.md
@@ -1,0 +1,61 @@
+# Teensy HEX Files
+
+This page explains how to compile the Teensy 4.1 firmware into HEX format
+for use with the Teensy Loader application.
+
+## Prerequisites
+
+- Arduino IDE 1.8.x or 2.x with Teensyduino and FastLED, or
+- PlatformIO (install via `pip install platformio`)
+
+## Arduino IDE (export HEX)
+
+1. Open `teensy_firmware/teensy_firmware.ino`.
+2. Select **Tools > Board > Teensy 4.1**.
+3. Select **Tools > USB Type > Serial**.
+4. Select **Tools > CPU Speed > 600 MHz**.
+5. Go to **Sketch > Export Compiled Binary**.
+
+Output:
+`teensy_firmware/teensy_firmware.ino.teensy41.hex`
+
+## PlatformIO (scripts)
+
+Linux/macOS:
+
+```bash
+./scripts/build_teensy_hex.sh
+```
+
+Windows:
+
+```cmd
+scripts\build_teensy_hex.bat
+```
+
+Output:
+`build_output/teensy41_firmware.hex`
+
+## PlatformIO (manual)
+
+```bash
+pio run -e teensy41 --target clean
+pio run -e teensy41
+```
+
+Output locations:
+- `.pio/build/teensy41/firmware.hex`
+- `build_output/teensy41_firmware.hex`
+
+## Load HEX with Teensy Loader
+
+1. Open Teensy Loader: https://www.pjrc.com/teensy/loader.html
+2. **File > Open HEX File**, select your HEX file.
+3. Press the white button on the Teensy 4.1 board.
+4. Click **Program** (or auto-program) and then **Reboot** if needed.
+
+## Troubleshooting
+
+- "Teensy board not found": install Teensyduino and restart Arduino IDE.
+- "FastLED library not found": install FastLED via Library Manager.
+- "HEX file not compatible": ensure the target board is Teensy 4.1.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,20 @@
+# Nebula Poi Wiki
+
+This wiki collects build and development information for the Nebula Poi
+project.
+
+## Build information
+
+- [Build overview](Build-Overview.md)
+- [Teensy firmware build](Build-Teensy-Firmware.md)
+- [Teensy HEX files](Build-Teensy-HEX.md)
+- [Teensy CLI compilation](Build-Teensy-CLI.md)
+- [ESP32 firmware build](Build-ESP32-Firmware.md)
+- [Android app build](Build-Android-App.md)
+- [Image converter builds](Build-Image-Converter.md)
+
+## Other docs
+
+- Project overview: ../README.md
+- Hardware wiring: ../docs/WIRING.md
+- API reference: ../docs/API.md


### PR DESCRIPTION
Migrate build-related documentation into a new wiki section to centralize and improve discoverability of build information.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f86b964-ce80-46d1-b5e6-57705239c089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7f86b964-ce80-46d1-b5e6-57705239c089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

