### PR TITLE
fix uploadfs failure when data directory is missing

### DIFF
--- a/esp32_firmware/README_COMPILE.md
+++ b/esp32_firmware/README_COMPILE.md
@@ -17,6 +17,17 @@ cd esp32_firmware
 pio run -e esp32s3
 ```
 
+#### Build and upload Web UI filesystem (SPIFFS):
+```bash
+cd esp32_firmware/webui
+npm run build
+
+cd ../
+pio run -e esp32s3 --target uploadfs
+```
+
+> `uploadfs` uses `webui/dist` directly (configured in `esp32_firmware/platformio.ini` as `data_dir = webui/dist`).
+
 #### Build and upload to COM8:
 ```bash
 cd esp32_firmware

--- a/esp32_firmware/platformio.ini
+++ b/esp32_firmware/platformio.ini
@@ -1,9 +1,10 @@
 ; PlatformIO Configuration for ESP32-S3 Firmware
 ; Board: ESP32-S3-DevKitC-1 N16R8 (16MB Flash, 8MB PSRAM)
-; Web UI is embedded inline — no separate SPIFFS data upload needed.
+; Web UI can be uploaded to SPIFFS from webui/dist via uploadfs.
 
 [platformio]
 src_dir = .
+data_dir = webui/dist
 
 [env:esp32s3]
 platform = espressif32


### PR DESCRIPTION
## Summary
- configure PlatformIO data_dir to webui/dist so pio run --target uploadfs no longer depends on a separate sp32_firmware/data folder
- update ESP32 compile docs with the exact WebUI build + SPIFFS upload flow
- align the platformio comment to reflect that SPIFFS upload is supported and expected

## Test plan
- [x] Run 
pm run build in sp32_firmware/webui
- [x] Run pio run -e esp32s3 --target uploadfs from sp32_firmware
- [x] Verify upload uses webui/dist in output and flashes successfully

Made with [Cursor](https://cursor.com)